### PR TITLE
Update README.md

### DIFF
--- a/tools/destination-connector-tester/README.md
+++ b/tools/destination-connector-tester/README.md
@@ -153,7 +153,7 @@ Here is an example input file named `input_1.json`:
 
 ## CLI Arguments
 
-The tester supports the following optional CLI arguments to alter its default behavior. You can append these options to the end of the `docker run` command provided in step 2 of [How To Run](https://github.com/fivetran/fivetran_sdk/tree/main/tools/destination-tester#how-to-run) section above.
+The tester supports the following optional CLI arguments to alter its default behavior. You can append these options to the end of the `docker run` command provided in step 2 of [How To Run](https://github.com/fivetran/fivetran_sdk/tree/main/tools/destination-connector-tester#how-to-run) section above.
 
 #### --port
 This option defines the port the tester should run on.

--- a/tools/source-connector-tester/README.md
+++ b/tools/source-connector-tester/README.md
@@ -34,7 +34,7 @@ docker start -i <container-id>
 
 ## CLI Arguments
 
-The tester supports the following optional CLI arguments to alter its default behavior. You can append these options to the end of the docker run command provided in step 2 of [How To Run](https://github.com/fivetran/fivetran_sdk/blob/main/tools/connector-tester/README.md#how-to-run) section above.
+The tester supports the following optional CLI arguments to alter its default behavior. You can append these options to the end of the docker run command provided in step 2 of [How To Run](https://github.com/fivetran/fivetran_sdk/tree/main/tools/source-connector-tester#how-to-run) section above.
 
 #### --port
 This option defines the port the tester should run on.


### PR DESCRIPTION
How To run link was broken in https://github.com/fivetran/fivetran_sdk/tree/main/tools/destination-connector-tester . Corrected it.